### PR TITLE
Fix npx command in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,13 @@ Git diff を見やすくするため、1文1行にします。
 
 ```bash
 # カレントディレクトリの sotsuron.tex を処理（上書き）
-npx @smkwlab/split-sentences
+npx github:smkwlab/split-sentences
 
 # 別のファイルを指定
-npx @smkwlab/split-sentences main.tex
+npx github:smkwlab/split-sentences main.tex
 
 # 出力ファイルを別に指定
-npx @smkwlab/split-sentences input.tex output.tex
+npx github:smkwlab/split-sentences input.tex output.tex
 ```
 
 ## 機能

--- a/split-sentences.js
+++ b/split-sentences.js
@@ -5,9 +5,9 @@
  * Git diff を見やすくするため、1文1行にする
  *
  * Usage:
- *   npx @smkwlab/split-sentences
- *   npx @smkwlab/split-sentences main.tex
- *   npx @smkwlab/split-sentences input.tex output.tex
+ *   npx github:smkwlab/split-sentences
+ *   npx github:smkwlab/split-sentences main.tex
+ *   npx github:smkwlab/split-sentences input.tex output.tex
  */
 
 const fs = require('fs');
@@ -16,7 +16,7 @@ const inputFile = process.argv[2] || 'sotsuron.tex';
 const outputFile = process.argv[3] || inputFile;
 
 if (process.argv[2] === '-h' || process.argv[2] === '--help') {
-  console.log('Usage: npx @smkwlab/split-sentences [input.tex] [output.tex]');
+  console.log('Usage: npx github:smkwlab/split-sentences [input.tex] [output.tex]');
   console.log('');
   console.log('Options:');
   console.log('  input.tex   Input LaTeX file (default: sotsuron.tex)');


### PR DESCRIPTION
## Summary

- Update npx command from `@smkwlab/split-sentences` to `github:smkwlab/split-sentences`
- The package is not published to npm registry, so GitHub URL is required

## Changes

- README.md: Fix usage examples
- split-sentences.js: Fix help message and comments