### PR TITLE
Ignore LaTeX comment lines when splitting sentences

### DIFF
--- a/split-sentences.js
+++ b/split-sentences.js
@@ -35,7 +35,8 @@ let content = fs.readFileSync(inputFile, 'utf-8');
 const preserved = [];
 
 // コメント部分を一時退避（% から行末まで、インラインコメントも含む）
-const commentRegex = /%.*$/gm;
+// ただし \% はエスケープされたリテラルなので除外
+const commentRegex = /(?<!\\)%.*$/gm;
 content = content.replace(commentRegex, (match) => {
   preserved.push(match);
   return `__PRESERVED_${preserved.length - 1}__`;
@@ -53,7 +54,7 @@ content = content.replace(verbatimRegex, (match) => {
 // ただし、閉じ括弧（）」）の直前は除外
 content = content.replace(/([。！？])(?![）」\n])/g, '$1\n');
 
-// 退避した領域を復元（コメント行、verbatim 環境）
+// 退避した領域を復元（コメント部分、verbatim 環境）
 content = content.replace(/__PRESERVED_(\d+)__/g, (_, i) => preserved[i]);
 
 fs.writeFileSync(outputFile, content, 'utf-8');

--- a/split-sentences.js
+++ b/split-sentences.js
@@ -34,8 +34,8 @@ let content = fs.readFileSync(inputFile, 'utf-8');
 // 保護する領域を一時退避
 const preserved = [];
 
-// コメント行を一時退避（% で始まる行全体を保護）
-const commentRegex = /^[ \t]*%.*$/gm;
+// コメント部分を一時退避（% から行末まで、インラインコメントも含む）
+const commentRegex = /%.*$/gm;
 content = content.replace(commentRegex, (match) => {
   preserved.push(match);
   return `__PRESERVED_${preserved.length - 1}__`;


### PR DESCRIPTION
## Summary

- LaTeX コメント部分（`%` から行末まで）を句点処理の対象外にする
- 行頭から始まるコメント行だけでなく、インラインコメント（行の途中から始まる `%`）も対応

## Changes

- コメント部分を verbatim 環境と同様に一時退避してから句点処理を行い、後で復元する処理を追加
- 正規表現 `/%.*$/gm` でコメント部分をマッチ

## Test

```latex
% 行頭コメント。改行が入らない。
本文です。改行される。 % インラインコメント。改行が入らない。
```

Closes #2